### PR TITLE
Remove supplemental.js module dependency

### DIFF
--- a/src/result.js
+++ b/src/result.js
@@ -1307,25 +1307,23 @@ var Result = CreateClass({
                         const supplementalInfo = supplemental.collectSkillInfo(skilldata.supplementalDamageArray, {remainHP: m.data[key].remainHP});
                         if (supplementalInfo.total > 0) {
                             supplementalDamageInfo.push(
-                                <table key={key + "-supplementalDamageTable"} className="table table-bordered" style={{"marginBottom": "0px"}} >
+                                <table key={key + "-supplementalDamageTable"} className="table table-bordered" style={{"marginBottom": "0px", "font-size": "10pt"}} >
                                     <thead>
                                         <tr>
-                                            <th className="bg-success" style={{"fontSize": "10pt"}}>{intl.translate("与ダメージ上昇効果のソース", locale)}</th>
-                                            {supplementalInfo.headers.map( function (head, ind) {
-                                                return <th key={ind} className="bg-success" style={{"fontSize": "10pt"}}>{supplemental.tableHeader(head, locale)}</th>;
-                                            })}
-                                            <th className="bg-success" style={{"fontSize": "10pt"}}>{intl.translate("合計", locale)}</th>
+                                            <th className="bg-success">{intl.translate("与ダメージ上昇効果のソース", locale)}</th>
+                                            {supplementalInfo.headers.map(([key, type, val]) =>
+                                                <th key={key} className="bg-success">
+                                                    {intl.translate(key, locale) + 
+                                                     (intl.translate("supplemental_"+type, locale)||"").replace("{value}", (val||"").toString())}
+                                                </th>)}
+                                            <th className="bg-success">{intl.translate("合計", locale)}</th>
                                         </tr>
                                     </thead>
                                     <tbody>
                                         <tr>
-                                            <td style={{"fontSize": "10pt"}}>{intl.translate("ダメージ", locale)}</td>
-                                            {supplementalInfo.values.map( function (v, ind) {
-                                                return (
-                                                    <td key={ind} style={{"fontSize": "10pt"}}>{v}</td>
-                                                )
-                                            })}
-                                            <td style={{"fontSize": "10pt"}}>
+                                            <td>{intl.translate("ダメージ", locale)}</td>
+                                            {supplementalInfo.values.map(([key, damage]) => <td key={key}>{damage}</td>)}
+                                            <td>
                                                 {supplementalInfo.total}&nbsp;
                                             </td>
                                         </tr>

--- a/src/supplemental.js
+++ b/src/supplemental.js
@@ -1,31 +1,15 @@
-var intl = require('./translate.js');
 
-function calcSupplementalDamage(types, damageArray, vals, {remainHP = 1.0, expectedTurn = 1}={}) {
+function calcSupplementalDamage(
+    types,
+    damageArray,
+    vals,
+    { remainHP = 1.0, expectedTurn = 1 } = {}
+) {
     for (let supplemental of Object.values(damageArray)) {
-        if (! types.includes(supplemental.type))
+        if (!types.includes(supplemental.type))
             continue;
 
         switch (supplemental.type) {
-            case "hp_based":
-                if (!("threshold" in supplemental)) {
-                    console.error("Missing HP threshold in: " + supplemental);
-                    continue;
-                }
-                if (remainHP < supplemental.threshold)
-                    continue;
-                /* FALLTHROUGH */
-            case "boss_debuff_based":
-                /* FALLTHROUGH */
-            case "djeeta_buff_based":
-                /* FALLTHROUGH */
-            case "on_critical":
-                /* FALLTHROUGH */
-            case "other":
-                vals[0] += supplemental.damage;
-                vals[1] += supplemental.damageWithoutCritical;
-                vals[2] += supplemental.ougiDamage;
-                vals[3] += supplemental.chainBurst;
-                break;
             case "third_hit":
                 if (expectedTurn === Infinity) {
                     expectedTurn = 1;
@@ -33,8 +17,21 @@ function calcSupplementalDamage(types, damageArray, vals, {remainHP = 1.0, expec
                 vals[0] += supplemental.damage;
                 vals[1] += supplemental.damage * expectedTurn;
                 break;
+            case "hp_based":
+                if (!("threshold" in supplemental)) {
+                    console.error("Missing HP threshold in: " + supplemental);
+                    continue;
+                }
+                if (remainHP < supplemental.threshold) {
+                    continue;
+                }
+            /* FALLTHROUGH */
             default:
-                console.error("unknown supplemental damage type: " + supplemental.type); //does not reach here typically, if ever.
+                // case "boss_debuff_based", "djeeta_buff_based", "on_critical"
+                vals[0] += supplemental.damage;
+                vals[1] += supplemental.damageWithoutCritical;
+                vals[2] += supplemental.ougiDamage;
+                vals[3] += supplemental.chainBurst;
                 break;
         }
     }
@@ -42,29 +39,31 @@ function calcSupplementalDamage(types, damageArray, vals, {remainHP = 1.0, expec
 }
 
 function collectSkillInfo(damageArray, {remainHP = 1.0}={}) {
-    const isAvailable = ([key, val]) => (!((val.type == "hp_based") && (remainHP < val.threshold)) && !(val.damage == 0));
-    const xs = Object.entries(damageArray).filter(isAvailable).sort();
+    const isAvailable = ([key, val]) =>
+        !((val.type == "hp_based") && (remainHP < val.threshold)) &&
+        !(val.damage == 0);
+    const xs = Object.entries(damageArray)
+        .filter(isAvailable)
+        .sort();
     return {
-        headers: xs.map(([key, val]) => [key, val.type, "additionalVal" in val ? val.additionalVal : null]),
-        values: xs.map(([key, val]) => val.damage),
+        headers: xs.map(([key, val]) => [key, val.type, val.additionalVal]),
+        values: xs.map(([key, val]) => [key, val.damage]),
         total: xs.reduce((total, [key,val]) => total + val.damage, 0),
     };
 }
 
-function tableHeader([key, type, additionalVal], locale) {
-    var str = intl.translate(key, locale);
-    if (type != undefined) {
-        str += intl.translate("supplemental_" + type, locale);
-        str = str.replace("{value}", additionalVal == null ? "" : additionalVal);
-    }
-    return str;
-}
-
 //exports
 module.exports._calcDamage = calcSupplementalDamage;
-module.exports.calcOthersDamage = calcSupplementalDamage.bind(null, ["other", "hp_based", "on_critical", "boss_debuff_based", "djeeta_buff_based"]);
-module.exports.calcThirdHitDamage = calcSupplementalDamage.bind(null, ["third_hit"]);
+module.exports.calcOthersDamage = calcSupplementalDamage.bind(null, [
+    "other",
+    "hp_based",
+    "on_critical",
+    "boss_debuff_based",
+    "djeeta_buff_based"
+]);
+module.exports.calcThirdHitDamage = calcSupplementalDamage.bind(null, [
+    "third_hit"
+]);
 
 module.exports.collectSkillInfo = collectSkillInfo;
 
-module.exports.tableHeader = tableHeader;

--- a/src/supplemental.test.js
+++ b/src/supplemental.test.js
@@ -132,11 +132,6 @@ describe("#collectSkillInfo", () => {
                 damage: 30,
                 type: "third_hit",
             },
-            // for damage=0 case
-            // 1. Add this test data first
-            // 2. Run test to confirm it's failed at keys() check
-            // 3. Add `&& (val.damage != 0)` to isAvailable
-            // 4. Run test to check pass
             "A": {
                 damage: 0,
                 type: "other",
@@ -163,46 +158,14 @@ describe("#collectSkillInfo", () => {
     // (Jasmine in codepen.io did not support the same method)
     it("test damageArray remainHP 100%,50%", () => {
         let {supplementalDamageArray} = this;
+        const toKey = ([key, type, additionalVal]) => key;
       
         let supplementalInfo = supplemental.collectSkillInfo(supplementalDamageArray, {remainHP: 1.00});
         expect(supplementalInfo.total).toEqual(80);
-        expect(supplementalInfo.headers).toEqual([
-            ["B", "hp_based", null],
-            ["C", "third_hit", null],
-            ["D", "other", null],
-            ["E", "on_critical", 50]
-        ]);
-        expect(supplementalInfo.values).toEqual([20, 30, 10, 20]);
+        expect(supplementalInfo.headers.map(toKey)).toEqual(["B", "C", "D", "E"]);
       
         supplementalInfo = supplemental.collectSkillInfo(supplementalDamageArray, {remainHP: 0.50});
         expect(supplementalInfo.total).toEqual(60);
-        expect(supplementalInfo.headers).toEqual([
-            ["C", "third_hit", null],
-            ["D", "other", null],
-            ["E", "on_critical", 50]
-        ]);
-        expect(supplementalInfo.values).toEqual([30, 10, 20]);
-    });
-});
-
-describe("#tableHeader", () => {
-
-    it("test empty head", () => {
-        let head = supplemental.tableHeader([], "en");
- 
-        expect(head).toEqual("");
-      
-    });
-  
-    test('test head locale:en', () => {
-        expect(supplemental.tableHeader(["バフ", undefined, 10], "en")).toEqual("Buff");
-        expect(supplemental.tableHeader(["修羅の誓約", "third_hit", undefined], "en")).toEqual("Contentious Covenant (Applies to third hit)");
-        expect(supplemental.tableHeader(["致命の誓約", "on_critical", 50], "en")).toEqual("Deleterious Covenant (Applies to critical hit, 50%)");
-    });
-  
-    test('test head locale:ja', () => {
-        expect(supplemental.tableHeader(["バフ", undefined, 10], "ja")).toEqual("バフ");
-        expect(supplemental.tableHeader(["修羅の誓約", "third_hit", undefined], "ja")).toEqual("修羅の誓約 (3回目の攻撃に)");
-        expect(supplemental.tableHeader(["致命の誓約", "on_critical", 50], "ja")).toEqual("致命の誓約 (クリティカル攻撃に、 50%)");
+        expect(supplementalInfo.headers.map(toKey)).toEqual(["C", "D", "E"]);
     });
 });


### PR DESCRIPTION
This patch contains various sub topics
Each topics are explained in MotocalDevelopers/motocal/pull/233

- supplemental.js
  - calcSupplementalDamage
    - rearrange cases in switch
    - minor coding style fix (as adviced by Prettier)
      - NOTE: FALLTHROUGH indent level
  - drop tableHeader function
  - and remove the translate.js dependency
- supplemental.test.js
  - drop tableHeader test
  - test only keys data for checking isAvailable works
- result.js
  - move a lot font-size styles to the parent element.
  - using arrow function
  - using supplementalDamageArray's key as list key
  - FIXME: now {value} replace logic is hard coded