### PR TITLE
Add CriticalBuffList component

### DIFF
--- a/src/chara.js
+++ b/src/chara.js
@@ -4,6 +4,7 @@ var {Label, Checkbox, FormControl, InputGroup, FormGroup, Button, ButtonGroup, P
 var CreateClass = require('create-react-class');
 var {RegisteredChara} = require('./template.js');
 var GlobalConst = require('./global_const.js');
+var {CriticalBuffList} = require('./components.js');
 
 // inject GlobalConst...
 var elementRelation = GlobalConst.elementRelation;
@@ -400,11 +401,7 @@ var Chara = CreateClass({
     handleSelectEvent: function (key, e) {
         var newState = this.state;
 
-        if (Array.isArray(key)) {
-            if (key.length == 3 && key[0] == "criticalBuff") {
-                newState[key[0]][key[1]][key[2]] = e.target.value/100;
-            }
-        } else if (e.target.type === "checkbox") {
+        if (e.target.type === "checkbox") {
             newState[key] = e.target.checked;
         } else {
             newState[key] = e.target.value;
@@ -632,10 +629,12 @@ var Chara = CreateClass({
                             <tr key="criticalBuff">
                                 <th className="bg-primary">{intl.translate("クリティカルバフ", locale)}</th>
                                 <td>
-                                    <strong>{intl.translate("数", locale)}</strong>
-                                    <FormControl type="number" min="0" value={this.state.criticalBuffCount}
-                                                 onBlur={this.handleOnBlur} onChange={this.handleSelectEvent.bind(this, "criticalBuffCount")}/>
-                                    {criticalBuffRender}
+                                    <CriticalBuffList locale={locale}
+                                        onBlur={this.handleOnBlur.bind(this, null)}
+                                        onCountChange={(count) => this.setState({criticalBuffCount: count})}
+                                        label="criticalBuff"
+                                        criticalArray={this.state.criticalBuff}
+                                        initialCount={this.state.criticalBuffCount} />
                                 </td>
                             </tr>,
                             <tr key="daBuff">

--- a/src/chara.js
+++ b/src/chara.js
@@ -456,22 +456,6 @@ var Chara = CreateClass({
     },
     render: function () {
         var locale = this.props.locale;
-        var criticalBuffRender = [];
-        for (let i = 0; i < this.state.criticalBuffCount; i++) {
-            criticalBuffRender[i] = (
-                <div key={"criticalBuff" + i}>
-                   <hr/>
-                   <strong>{intl.translate("発動率", locale)}#{i+1}</strong>
-                   <InputGroup><FormControl componentClass="select" value={100*this.state.criticalBuff[i]["value"]}
-                                            onBlur={this.handleOnBlur} onChange={this.handleSelectEvent.bind(this, ["criticalBuff", i, "value"])}>{selector.criticalRateLevel}</FormControl>
-                   <InputGroup.Addon>%</InputGroup.Addon></InputGroup>
-                   <strong>{intl.translate("倍率", locale)}#{i+1}</strong>
-                   <InputGroup><FormControl componentClass="select" value={100*this.state.criticalBuff[i]["attackRatio"]}
-                                            onBlur={this.handleOnBlur} onChange={this.handleSelectEvent.bind(this, ["criticalBuff", i, "attackRatio"])}>{selector.buffLevel}</FormControl>
-                   <InputGroup.Addon>%</InputGroup.Addon></InputGroup>
-                </div>
-            );
-        }
 
         return (
             <div className="chara-content">

--- a/src/components.js
+++ b/src/components.js
@@ -1,0 +1,134 @@
+"use strict";
+
+const React = require('react');
+const {FormControl, InputGroup} = require('react-bootstrap');
+const intl = require('./translate.js');
+const {selector} = require('./global_const.js');
+
+
+/**
+ * Dynamic List component for Critical Buff inputs
+ */
+class CriticalBuffList extends React.Component {
+
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            count: props.initialCount || props.criticalArray.length,
+            array: props.criticalArray
+        };
+    }
+
+    /**
+     * Notify event
+     *
+     * @param {number} count
+     */
+    handleOnCountChange(count) {
+        if (this.props.onCountChange) {
+            this.props.onCountChange(count);
+        }
+    }
+
+    /**
+     * Notify event
+     *
+     * @param {string} key ... UNUSED
+     * @param {Object} e  ... Event object
+     */
+    handleOnBlur(key, e){
+        console.log(this, key, e)
+        if (this.props.onBlur) {
+            this.props.onBlur(e);
+        }
+    }
+
+    /**
+     * @param {string} key
+     * @param {number} idx
+     * @param {Object} e  ... Event object
+     *
+     * when key is "count":
+     *   Change array's size if needed.
+     *
+     * when key is "value" or "attackRatio":
+     *   update value
+     *
+     */
+    handleOnChange(key, idx, e) {
+        let array = this.props.criticalArray;
+        
+        if (key === "count") {
+            const count = e.target.value;
+
+            while (count > array.length) {
+                array.push({value: 0.0, attackRatio: 0.0});
+            }
+            if (array.length > count && this.props.truncate) {
+                array.length = count;
+            }
+
+            this.setState({count: count, array: array});
+            this.handleOnCountChange(count);
+        } else if (key === "value" || key === "attackRatio") {
+            const val = parseInt(e.target.value);
+
+            array[idx][key] = val / 100;
+
+            this.setState({array: array});
+        }
+    }
+
+    /**
+     * Render Count form and list of Value/AttackRatio forms
+     *
+     * @return {ReactElement}
+     */
+    render() {
+        const {state: {count, array}, props: {locale, label, maxCount}} = this;
+
+        return <React.Fragment>
+            <strong>{intl.translate("数", locale)}</strong>
+            <FormControl type="number"
+              min="0" max={maxCount} value={count}
+              onBlur={this.handleOnBlur.bind(this)}
+              onChange={this.handleOnChange.bind(this, "count", null)}/>
+            {array.slice(0, count).map(({value,attackRatio}, idx) =>
+            <div key={label + idx}>
+                <strong>{intl.translate("発動率", locale)}#{idx+1}</strong>
+                <InputGroup>
+                    <FormControl
+                      componentClass="select"
+                      value={Math.round(100*value)}
+                      onBlur={this.handleOnBlur.bind(this)}
+                      onChange={this.handleOnChange.bind(this, "value", idx)}>
+                      {selector.criticalRateLevel}
+                    </FormControl>
+                    <InputGroup.Addon>%</InputGroup.Addon>
+                </InputGroup>
+                <strong>{intl.translate("倍率", locale)}#{idx+1}</strong>
+                <InputGroup>
+                    <FormControl
+                      componentClass="select"
+                      value={Math.round(100*attackRatio)}
+                      onBlur={this.handleOnBlur.bind(this)}
+                      onChange={this.handleOnChange.bind(this, "attackRatio", idx)}>
+                    {selector.buffLevel}
+                    </FormControl>
+                    <InputGroup.Addon>%</InputGroup.Addon>
+                </InputGroup>
+            </div>)}
+        </React.Fragment>;
+    }
+}
+
+CriticalBuffList.defaultProps = {
+    maxCount: 20,
+    initialCount: 0,
+    truncate: true,
+    label: "criticalBuff",
+};
+
+
+module.exports.CriticalBuffList = CriticalBuffList;

--- a/src/profile.js
+++ b/src/profile.js
@@ -4,6 +4,7 @@ var intl = require('./translate.js');
 var GlobalConst = require('./global_const.js');
 var TextWithTooltip = GlobalConst.TextWithTooltip;
 var CreateClass = require('create-react-class');
+var {CriticalBuffList} = require('./components.js');
 
 // const
 var zenith = GlobalConst.zenith;
@@ -245,11 +246,7 @@ var Profile = CreateClass({
     handleSelectEvent: function (key, e) {
         // A select type input form is good for onChange
         var newState = this.state;
-        if (Array.isArray(key)) {
-            if (key.length == 3 && (key[0] == 'criticalBuff' || key[0] == 'personalCriticalBuff')) {
-                newState[key[0]][key[1]][key[2]] = e.target.value/100;
-            }
-        } else if (e.target.type === "checkbox") {
+        if (e.target.type === "checkbox") {
             newState[key] = e.target.checked;
         } else {
             newState[key] = e.target.value;
@@ -272,42 +269,6 @@ var Profile = CreateClass({
     },
     render: function () {
         var locale = this.props.locale;
-        //Generate Critical Buff Fields
-        var criticalBuffRender = [];
-        if (this.state.criticalBuff.length != this.state.criticalBuffCount) this.state.criticalBuff = this.state.criticalBuff.slice(0, this.state.criticalBuffCount);
-            for (var i = 0; i < this.state.criticalBuffCount; i++) {
-                if (this.state.criticalBuff[i] == undefined) this.state.criticalBuff[i] = {"value": 0.0, "attackRatio": 0.0};
-                    criticalBuffRender[i] = (
-                    <div key={"criticalBuff" + i}>
-                       <hr/>
-                       <strong>{intl.translate("発動率", locale)}#{i+1}</strong>
-                       <InputGroup><FormControl componentClass="select" value={100*this.state.criticalBuff[i]["value"]}
-                                                onBlur={this.handleOnBlur} onChange={this.handleSelectEvent.bind(this, ["criticalBuff", i, "value"])}>{selector.criticalRateLevel}</FormControl>
-                       <InputGroup.Addon>%</InputGroup.Addon></InputGroup>
-                       <strong>{intl.translate("発動率", locale)}#{i+1}</strong>
-                       <InputGroup><FormControl componentClass="select" value={100*this.state.criticalBuff[i]["attackRatio"]}
-                                                onBlur={this.handleOnBlur} onChange={this.handleSelectEvent.bind(this, ["criticalBuff", i, "attackRatio"])}>{selector.buffLevel}</FormControl>
-                       <InputGroup.Addon>%</InputGroup.Addon></InputGroup>
-                    </div>);
-            }
-        //Djeeta's
-        var personalCriticalBuffRender = [];
-        if (this.state.personalCriticalBuff.length != this.state.personalCriticalBuffCount) this.state.personalCriticalBuff = this.state.personalCriticalBuff.slice(0, this.state.personalCriticalBuffCount);
-        for (var i = 0; i < this.state.personalCriticalBuffCount; i++) {
-            if (this.state.personalCriticalBuff[i] == undefined) this.state.personalCriticalBuff[i] = {"value": 0.0, "attackRatio": 0.0};
-                personalCriticalBuffRender[i] = (
-                <div key={"personalCriticalBuff" + i}>
-                   <hr/>
-                   <strong>{intl.translate("発動率", locale)}#{i+1}</strong>
-                   <InputGroup><FormControl componentClass="select" value={100*this.state.personalCriticalBuff[i]["value"]}
-                                            onBlur={this.handleOnBlur} onChange={this.handleSelectEvent.bind(this, ["personalCriticalBuff", i, "value"])}>{selector.criticalRateLevel}</FormControl>
-                   <InputGroup.Addon>%</InputGroup.Addon></InputGroup>
-                   <strong>{intl.translate("倍率", locale)}#{i+1}</strong>
-                   <InputGroup><FormControl componentClass="select" value={100*this.state.personalCriticalBuff[i]["attackRatio"]}
-                                            onBlur={this.handleOnBlur} onChange={this.handleSelectEvent.bind(this, ["personalCriticalBuff", i, "attackRatio"])}>{selector.buffLevel}</FormControl>
-                   <InputGroup.Addon>%</InputGroup.Addon></InputGroup>
-                </div>);
-        }
 
         return (
             <div className="profile">
@@ -438,10 +399,12 @@ var Profile = CreateClass({
                             <tr key="personalCriticalBuff">
                                 <th className="bg-primary">{intl.translate("クリティカルバフ", locale)}</th>
                                 <td>
-                                    <strong>{intl.translate("数", locale)}</strong>
-                                    <FormControl type="number" min="0" value={this.state.personalCriticalBuffCount}
-                                                 onBlur={this.handleOnBlur} onChange={this.handleSelectEvent.bind(this, "personalCriticalBuffCount")}/>
-                                    {personalCriticalBuffRender}
+                                    <CriticalBuffList locale={locale}
+                                        onBlur={this.handleOnBlur.bind(this)}
+                                        onCountChange={(count) => this.setState({personalCriticalBuffCount: count})}
+                                        label="personalCriticalBuff"
+                                        criticalArray={this.state.personalCriticalBuff}
+                                        initialCount={this.state.personalCriticalBuffCount} />
                                 </td>
                             </tr>,
                             <tr key="personalDaBuff">
@@ -776,10 +739,12 @@ var Profile = CreateClass({
                         <tr>
                             <th className="bg-primary">{intl.translate("クリティカルバフ", locale)}</th>
                             <td>
-                                <strong>{intl.translate("数", locale)}</strong>
-                                <FormControl type="number" min="0" value={this.state.criticalBuffCount}
-                                             onBlur={this.handleOnBlur} onChange={this.handleSelectEvent.bind(this, "criticalBuffCount")}/>
-                                {criticalBuffRender}
+                                <CriticalBuffList locale={locale}
+                                    onBlur={this.handleOnBlur.bind(this)}
+                                    onCountChange={(count) => this.setState({criticalBuffCount: count})}
+                                    label="criticalBuff"
+                                    criticalArray={this.state.criticalBuff}
+                                    initialCount={this.state.criticalBuffCount} />
                             </td>
                         </tr>
                     </TextWithTooltip>

--- a/src/stories/index.js
+++ b/src/stories/index.js
@@ -17,6 +17,7 @@ import { Chara } from '../chara';
 import { Arm } from '../armlist';
 import { Result } from '../result';
 import Notice from '../notice';
+import { CriticalBuffList } from '../components';
 
 
 var localeSelector = (groupId) => select('locale', ['ja', 'en', 'zh'], 'ja', groupId);
@@ -35,6 +36,24 @@ storiesOf('How To', module)
     .add('Nite(DA)', () => <NiteHowTo />)
     .add('HP Chart', () => <HPChartHowTo show="true" />)
     .add('Simulator', () => <SimulatorHowTo />);
+
+storiesOf('Components', module)
+    .addDecorator(centered)
+    .addDecorator(withKnobs)
+    .add('CriticalBuffList (maxCount=5)', () =>
+        <CriticalBuffList locale={localeSelector('criticalBuffListA-locale')}
+            onBlur={action('onBlur')}
+            onCountChange={action('onCountChange')}
+            label="criticalBuffA"
+            criticalArray={[{value: 0.5, attackRatio: 0.5}]}
+            maxCount={5} />)
+    .add('CriticalBuffList (truncate=false)', () =>
+        <CriticalBuffList locale={localeSelector('criticalBuffListB-locale')}
+            onBlur={action('onBlur')}
+            onCountChange={action('onCountChange')}
+            label="criticalBuffB"
+            criticalArray={[]}
+            truncate={false} />);
 
 storiesOf('Notice', module)
     .addDecorator(withKnobs)


### PR DESCRIPTION
PR for MotocalDevelopers/motocal/pull/250

This component will reduce 3 clone codes in profile, chara

Added optional Count change behavior, truncate=false option
that does not truncate array when count was changed.

`trancate=false` and set `initialCount` can keep modified array
but only "count" length available.

- Usage storybook -> components -> CriticaBuffList
  - properties
    - criticalArray (required)
    - label (default: criticalBuff) ... used for key prefix
    - maxCount (default: 20)
    - truncate (default: true)
    - initialCount (default: 0)
    - onBlur
    - onCountChange

----
## Test Storybook

- http://gitpod.io/#https://github.com/kei-gbf/motocal/tree/review-pr250
- npm install
- npm run storybook
  - Expose
  - Open Browser
  - Components -> CriticalBuffList  two samples

Test truncate=false mode behavior (default: true)

- add list item
- change value
- decrement count
- increment count ... see the last changed value was kept