### PR TITLE
Add support.range filtering

### DIFF
--- a/charaData.json
+++ b/charaData.json
@@ -1328,7 +1328,7 @@
         "sex": "male",
         "fav1": "sword",
         "fav2": "none",
-        "support": "element_buff_boost_own_30_ca_specs_20",
+        "support": "element_buff_boost_own_30",
         "support2": "none",
         "support3": "none",
         "minhp": "230",

--- a/scripts/chara_data_converter.py
+++ b/scripts/chara_data_converter.py
@@ -84,7 +84,8 @@ supportAbilist["atk_up_depends_races"] = {
     u"氷晶宮の特使"
 }
 supportAbilist["element_buff_boost_own_30"] = {
-    u"王者の風格"
+    u"王者の風格",
+    u"覇者の風格"
 }
 supportAbilist["eternal_wisdom"] = {
     u"久遠の叡智"
@@ -226,9 +227,6 @@ supportAbilist["element_buff_boost_wind_30"] = {
 # }
 supportAbilist["element_buff_boost_wind_15"] = {
     u"精霊の啓示"
-}
-supportAbilist["element_buff_boost_own_30_ca_specs_20"] = {
-    u"覇者の風格"
 }
 supportAbilist["critical_cap_up_light_3"] = {
     u"スポッター"

--- a/src/global_const.js
+++ b/src/global_const.js
@@ -3,6 +3,7 @@ var {Tooltip, OverlayTrigger} = require('react-bootstrap');
 var intl = require('./translate.js');
 var PropTypes = require('prop-types');
 var CreateClass = require('create-react-class');
+const {range} = require("./support_filter.js");
 
 module.exports.TextWithTooltip = CreateClass({
     render: function () {
@@ -1979,9 +1980,9 @@ var supportAbilities = {
         "value": 0.10
     },
     "element_buff_boost_own_30": {
-        "name": "属性バフ付与時に属性攻撃30%UP(パーシヴァル)",
+        "name": "属性バフ付与時に属性攻撃30%UP(パーシヴァル,アグロヴァル)",
         "type": "element_buff_boost",
-        "range": "own",
+        "range": range.own,
         "value": 0.30
     },
     "eternal_wisdom": {
@@ -2173,67 +2174,56 @@ var supportAbilities = {
     "element_buff_boost_fire_30": {
         "name": "味方全体の強化効果「火属性攻撃UP」の効果30%UP。(シヴァ)",
         "type": "element_buff_boost",
-        "range": "fire",
+        "range": range.element("fire"),
         "value": 0.30
     },
     "element_buff_boost_water_30": {
         "name": "味方全体の強化効果「水属性攻撃UP」の効果30%UP。(エウロペ)",
         "type": "element_buff_boost",
-        "range": "water",
+        "range": range.element("water"),
         "value": 0.30
     },
     "element_buff_boost_earth_30": {
         "name": "味方全体の強化効果「土属性攻撃UP」の効果30%UP。(ブローディア)",
         "type": "element_buff_boost",
-        "range": "earth",
+        "range": range.element("earth"),
         "value": 0.30
     },
     "element_buff_boost_wind_30": {
         "name": "味方全体の強化効果「風属性攻撃UP」の効果30%UP。(グリームニル)",
         "type": "element_buff_boost",
-        "range": "wind",
+        "range": range.element("wind"),
         "value": 0.30
     },
     "element_buff_boost_wind_15": {
         "name": "味方全体の強化効果「風属性攻撃UP」の効果15%UP。(コッコロ)",
         "type": "element_buff_boost",
-        "range": "wind",
+        "range": range.element("wind"),
         "value": 0.15
     },
-    "element_buff_boost_light_30": {
+    "element_buff_boost_light_30": { // UNUSED
         "name": "味方全体の強化効果「光属性攻撃UP」の効果30%UP。",
         "type": "element_buff_boost",
-        "range": "light",
+        "range": range.element("light"),
         "value": 0.30
     },
-    "element_buff_boost_dark_30": {
+    "element_buff_boost_dark_30": { // UNUSED
         "name": "味方全体の強化効果「闇属性攻撃UP」の効果30%UP。",
         "type": "element_buff_boost",
-        "range": "dark",
+        "range": range.element("dark"),
         "value": 0.30
     },
-    "element_buff_boost_all_30": {
+    "element_buff_boost_all_30": { // UNUSED
         "name": "味方全体の強化効果「属性攻撃UP」の効果30%UP。",
         "type": "element_buff_boost",
-        "range": "all",
+        "range": range.element("all"),
         "value": 0.30
     },
-    "element_buff_boost_own_30_ca_specs_20": {
-        "name": "属性バフ付与時に属性攻撃15%UPと奥義性能UP(ダメージと上限20%)。(アグロヴァル)",
-        "type": "element_buff_boost_own_30_ca_specs_20",
-        "range": "own",
-        "value": 0.30,
-        "ougiDamageBuff": 0.20,
-        "ougiDamageLimitBuff": 0.20,
-    },
     "shinryu_to_no_kizuna": {
-        "name": "属性攻撃UPが付与されている時、自分の攻撃UPと奥義性能UP(ダメージと上限20%)。(ヘルエス(風属性ver))",
+        "name": "属性攻撃UPが付与されている時、自分の攻撃UP。(ヘルエス(風属性ver)",
         "type": "shinryu_to_no_kizuna",
         "range": "own",
-        "value": 0.0,
-        "normalBuff": 0.30,
-        "ougiDamageBuff": 0.20,
-        "ougiDamageLimitBuff": 0.20,
+        "value": 0.30
     },
     "mamoritai_kono_egao": {
         "name": "自分以外の味方の攻5%UPとクリティカル確率UP(発動率20%, 倍率20%)。(ヤイア)",
@@ -2279,13 +2269,13 @@ var supportAbilities = {
     "critical_cap_up_light_3": {
         "name": "光属性キャラがクリティカル発動時にダメージ上限3%UP。(シルヴァ(光属性ver))",
         "type": "critical_cap_up",
-        "range": "light",
+        "range": range.element("light"),
         "value": 0.03,
     },
     "critical_cap_up_own_10": {
         "name": "クリティカル発動時にダメージ上限10%UP。(オイゲン(リミテッドver))",
         "type": "critical_cap_up",
-        "range": "own",
+        "range": range.own,
         "value": 0.10,
     },
     // "no_normal_attack": { //lyria, 優しい心; sakura kinomoto, 絶対だいじょうぶだよ >> カードキャプター

--- a/src/global_const.js
+++ b/src/global_const.js
@@ -2220,7 +2220,7 @@ var supportAbilities = {
         "value": 0.30
     },
     "shinryu_to_no_kizuna": {
-        "name": "属性攻撃UPが付与されている時、自分の攻撃UP。(ヘルエス(風属性ver)",
+        "name": "属性攻撃UPが付与されている時、自分の攻撃UP。(ヘルエス(風属性ver))",
         "type": "shinryu_to_no_kizuna",
         "range": "own",
         "value": 0.30

--- a/src/global_const.js
+++ b/src/global_const.js
@@ -2174,49 +2174,49 @@ var supportAbilities = {
     "element_buff_boost_fire_30": {
         "name": "味方全体の強化効果「火属性攻撃UP」の効果30%UP。(シヴァ)",
         "type": "element_buff_boost",
-        "range": range.element("fire"),
+        "range": range.element.fire,
         "value": 0.30
     },
     "element_buff_boost_water_30": {
         "name": "味方全体の強化効果「水属性攻撃UP」の効果30%UP。(エウロペ)",
         "type": "element_buff_boost",
-        "range": range.element("water"),
+        "range": range.element.water,
         "value": 0.30
     },
     "element_buff_boost_earth_30": {
         "name": "味方全体の強化効果「土属性攻撃UP」の効果30%UP。(ブローディア)",
         "type": "element_buff_boost",
-        "range": range.element("earth"),
+        "range": range.element.earth,
         "value": 0.30
     },
     "element_buff_boost_wind_30": {
         "name": "味方全体の強化効果「風属性攻撃UP」の効果30%UP。(グリームニル)",
         "type": "element_buff_boost",
-        "range": range.element("wind"),
+        "range": range.element.wind,
         "value": 0.30
     },
     "element_buff_boost_wind_15": {
         "name": "味方全体の強化効果「風属性攻撃UP」の効果15%UP。(コッコロ)",
         "type": "element_buff_boost",
-        "range": range.element("wind"),
+        "range": range.element.wind,
         "value": 0.15
     },
     "element_buff_boost_light_30": { // UNUSED
         "name": "味方全体の強化効果「光属性攻撃UP」の効果30%UP。",
         "type": "element_buff_boost",
-        "range": range.element("light"),
+        "range": range.element.light,
         "value": 0.30
     },
     "element_buff_boost_dark_30": { // UNUSED
         "name": "味方全体の強化効果「闇属性攻撃UP」の効果30%UP。",
         "type": "element_buff_boost",
-        "range": range.element("dark"),
+        "range": range.element.dark,
         "value": 0.30
     },
     "element_buff_boost_all_30": { // UNUSED
         "name": "味方全体の強化効果「属性攻撃UP」の効果30%UP。",
         "type": "element_buff_boost",
-        "range": range.element("all"),
+        "range": range.all,
         "value": 0.30
     },
     "shinryu_to_no_kizuna": {
@@ -2269,7 +2269,7 @@ var supportAbilities = {
     "critical_cap_up_light_3": {
         "name": "光属性キャラがクリティカル発動時にダメージ上限3%UP。(シルヴァ(光属性ver))",
         "type": "critical_cap_up",
-        "range": range.element("light"),
+        "range": range.element.light,
         "value": 0.03,
     },
     "critical_cap_up_own_10": {

--- a/src/global_logic.js
+++ b/src/global_logic.js
@@ -28,6 +28,7 @@ var raceTypes = GlobalConst.raceTypes;
 var sexTypes = GlobalConst.sexTypes;
 var filterElementTypes = GlobalConst.filterElementTypes;
 var enemyDefenseType = GlobalConst.enemyDefenseType;
+const {when} = require('./support_filter');
 
 module.exports.isCosmos = function (arm) {
     return (skilltypes[arm.skill1] != undefined && skilltypes[arm.skill1].type == "cosmosArm") ||
@@ -2694,43 +2695,16 @@ module.exports.treatSupportAbility = function (totals, chara, buff) {
                     }
                     continue;
                 case "shinryu_to_no_kizuna":
-                    if (totals[key]["elementBuff"] > 0 || buff["element"] > 0) {
-                        totals[key]["normalBuff"] += support.normalBuff;
+                    if (when.element_buff(chara, buff)) {
+                        totals[key]["normalBuff"] += support.value;
                     }
-                /* FALLTHROUGH */
-                case "element_buff_boost_own_30_ca_specs_20":
-                    if (( support.type == "element_buff_boost_own_30_ca_specs_20" || support.type == "shinryu_to_no_kizuna")
-                        && (totals[key]["elementBuff"] > 0 || buff["element"] > 0)) {
-                        totals[key]["ougiDamageBuff"] += support.ougiDamageBuff;
-                        totals[key]["ougiDamageLimitBuff"] += support.ougiDamageLimitBuff;
-                    }
-                /* FALLTHROUGH */
+                    continue;
                 case "element_buff_boost":
-                    if (support.range == "own") {
-                        if (totals[key]["elementBuff"] > 0 || buff["element"] > 0) {
-                            totals[key]["elementBuffBoostBuff"] = Math.max(support.value, totals[key]["elementBuffBoostBuff"]);
+                    for (let [name, chara] of support.range(totals, key)) {
+                        if (when.element_buff(chara, buff)) {
+                            chara["elementBuffBoostBuff"] = Math.max(support.value, chara["elementBuffBoostBuff"]);
                         }
-                    } else if (support.range == "all" && totals[key].isConsideredInAverage) {
-                        for (key2 in totals) {
-                            if (totals[key2]["elementBuff"] > 0 || buff["element"] > 0) {
-                                totals[key2]["elementBuffBoostBuff"] = Math.max(support.value, totals[key2]["elementBuffBoostBuff"]);
-                            }
-                        }
-                    } else if (support.range == "all" && !totals[key].isConsideredInAverage) {
-                        totals[key]["elementBuffBoostBuff"] = Math.max(support.value, totals[key]["elementBuffBoostBuff"]);
-                    } else {
-                        if (totals[key].isConsideredInAverage) {
-                            for (key2 in totals) {
-                                if (totals[key2].element == support.range && (totals[key2]["elementBuff"] > 0 || buff["element"] > 0)) {
-                                    totals[key2]["elementBuffBoostBuff"] = Math.max(support.value, totals[key2]["elementBuffBoostBuff"]);
-                                }
-                            }
-                        } else {
-                            if (totals[key]["elementBuff"] > 0 || buff["element"] > 0) {
-                                totals[key]["elementBuffBoostBuff"] = Math.max(support.value, totals[key]["elementBuffBoostBuff"]);
-                            }
-                        }
-                   }
+                    }
                     continue;
                 case "eternal_wisdom":
                     if (totals[key]["elementBuff"] > 0 || buff["element"] > 0) {
@@ -2856,32 +2830,17 @@ module.exports.treatSupportAbility = function (totals, chara, buff) {
                     totals[key]["additionalDamageTA"] += support.additionalDamageTA;
                     continue;
                 case "element_buff_boost_damageUP_own_10":
-                    if (totals[key]["elementBuff"] > 0 || buff["element"] > 0) {
+                    if (when.element_buff(totals[key], buff)) {
                         totals[key]["charaDamageUP"] += support.value;
                     }
                     continue;
                 case "critical_cap_up":
-                     if (support.range == "own") {
-                        totals[key]["criticalDamageLimit"] += support.value;
-                    } else if (support.range == "all" && totals[key].isConsideredInAverage) {
-                        for (let key2 in totals) {
-                            totals[key2]["criticalDamageLimit"] += support.value;
-                        }
-                    } else if (support.range == "all" && !totals[key].isConsideredInAverage) {
-                        totals[key]["criticalDamageLimit"] += support.value;
-                    } else {
-                        if (totals[key].isConsideredInAverage) {
-                            for (key2 in totals) {
-                                if (totals[key2].element == support.range) {
-                                    totals[key2]["criticalDamageLimit"] += support.value;
-                                }
-                            }
-                        } else {
-                            totals[key]["criticalDamageLimit"] += support.value;
-                        }
+                    for (let [name, chara] of support.range(totals, key)) {
+                        chara["criticalDamageLimit"] += support.value;
                     }
                     continue;
                 case "no_normal_attack":
+                    continue;
                 case "normalSupportKonshin_hpDebuff":
                     totals[key]["HPdebuff"] += support.hpDebuff;
                     // falls through

--- a/src/support_filter.js
+++ b/src/support_filter.js
@@ -1,0 +1,58 @@
+"use strict";
+
+
+const _entries = Object.entries;
+
+// no need to care isConsideredInAverage, and default for isConsideredInAverage: off case.
+const range_own = (totals, key) => [[key, totals[key]]];
+
+// no use range_custom_func because no need ".filter"
+const range_all = (totals, key) => 
+  (!totals[key].isConsideredInAverage) ? range_own(totals, key) : _entries(totals);
+
+// no use range_custom_func because need "key"
+const range_others = (totals, key) =>
+  (!totals[key].isConsideredInAverage) ? range_own(totals, key) : _entries(totals).filter(([k,v]) => k != key);
+
+// Base filtering function takes parameter totals and key
+// if totals[key].isConsideredInAverage then return range_own
+const range_custom_func = (func) => (totals, key) => 
+  (!totals[key].isConsideredInAverage) ? range_own(totals, key) : _entries(totals).filter(func);
+
+// Wrapper for range_custom, for simplify the function argument specs.
+const range_custom = (func) => range_custom_func(([k,v]) => func(v));
+
+
+// sample filters commonly use
+
+const range_element = (element) => range_custom(v => v.element == element);
+
+const range_race = (race) => range_custom(v => v.race == race);
+
+// TODO: Support two favorite weapons.
+const range_fav = (fav) => range_custom(v => [v.fav1, v.fav2].includes(fav));
+
+const range_sex = (sex) => range_custom(v => v.sex === sex);
+
+
+const when_element_buff = (chara, buff) => (chara.elementBuff > 0 || buff.element > 0);
+
+
+module.exports = {
+    range: {
+        own: range_own,
+        all: range_all,
+        others: range_others,
+
+        element: range_element,
+        race: range_race,
+        fav: range_fav,
+        sex: range_sex,
+
+        custom: range_custom,
+        custom_func: range_custom_func,
+    },
+    when: {
+        element_buff: when_element_buff,
+    }
+};

--- a/src/support_filter.js
+++ b/src/support_filter.js
@@ -3,6 +3,8 @@
 
 const _entries = Object.entries;
 
+const range_none = (totals, key) => [];
+
 // no need to care isConsideredInAverage, and default for isConsideredInAverage: off case.
 const range_own = (totals, key) => [[key, totals[key]]];
 
@@ -13,6 +15,10 @@ const range_all = (totals, key) =>
 // no use range_custom_func because need "key"
 const range_others = (totals, key) =>
   (!totals[key].isConsideredInAverage) ? range_own(totals, key) : _entries(totals).filter(([name, chara]) => name != key);
+
+const range_Djeeta = (totals, key) =>
+  (!totals[key].isConsideredInAverage) ? range_none(totals, key) : range_own(totals, "Djeeta");
+
 
 // Base filtering function takes parameter totals and key
 // if totals[key].isConsideredInAverage then return range_own
@@ -43,6 +49,8 @@ module.exports = {
         own: range_own,
         all: range_all,
         others: range_others,
+        none: range_none,
+        Djeeta: range_Djeeta,
 
         element: range_element,
         race: range_race,

--- a/src/support_filter.js
+++ b/src/support_filter.js
@@ -33,12 +33,29 @@ const range_custom = (func) => range_custom_func(([name, chara]) => func(chara))
 
 const range_element = (element) => range_custom(chara => chara.element == element);
 
+Object.assign(range_element, {
+    fire: range_element("fire"),
+    water: range_element("water"),
+    wind: range_element("wind"),
+    earth: range_element("earth"),
+    light: range_element("light"),
+    dark: range_element("dark"),
+});
+
+// FIXME: This race check is now not completed.
+// e.g. baha race check will match to "unknown", "seisyo"
 const range_race = (race) => range_custom(chara => chara.race == race);
 
 // TODO: Support two favorite weapons.
 const range_fav = (fav) => range_custom(chara => [chara.fav1, chara.fav2].includes(fav));
 
 const range_sex = (sex) => range_custom(chara => chara.sex === sex);
+
+Object.assign(range_sex, {
+    male: range_sex("male"),
+    female: range_sex("female"),
+    other: range_sex("other"),
+});
 
 
 const when_element_buff = (chara, buff) => (chara.elementBuff > 0 || buff.element > 0);

--- a/src/support_filter.js
+++ b/src/support_filter.js
@@ -43,7 +43,7 @@ Object.assign(range_element, {
 });
 
 // FIXME: This race check is now not completed.
-// e.g. baha race check will match to "unknown", "seisyo"
+// e.g. baha race check will match to "unknown", "seisho"
 const range_race = (race) => range_custom(chara => chara.race == race);
 
 // TODO: Support two favorite weapons.

--- a/src/support_filter.js
+++ b/src/support_filter.js
@@ -12,27 +12,27 @@ const range_all = (totals, key) =>
 
 // no use range_custom_func because need "key"
 const range_others = (totals, key) =>
-  (!totals[key].isConsideredInAverage) ? range_own(totals, key) : _entries(totals).filter(([k,v]) => k != key);
+  (!totals[key].isConsideredInAverage) ? range_own(totals, key) : _entries(totals).filter(([name, chara]) => name != key);
 
 // Base filtering function takes parameter totals and key
 // if totals[key].isConsideredInAverage then return range_own
 const range_custom_func = (func) => (totals, key) => 
   (!totals[key].isConsideredInAverage) ? range_own(totals, key) : _entries(totals).filter(func);
 
-// Wrapper for range_custom, for simplify the function argument specs.
-const range_custom = (func) => range_custom_func(([k,v]) => func(v));
+// Wrapper for range_custom_func, for simplify the function argument specs.
+const range_custom = (func) => range_custom_func(([name, chara]) => func(chara));
 
 
 // sample filters commonly use
 
-const range_element = (element) => range_custom(v => v.element == element);
+const range_element = (element) => range_custom(chara => chara.element == element);
 
-const range_race = (race) => range_custom(v => v.race == race);
+const range_race = (race) => range_custom(chara => chara.race == race);
 
 // TODO: Support two favorite weapons.
-const range_fav = (fav) => range_custom(v => [v.fav1, v.fav2].includes(fav));
+const range_fav = (fav) => range_custom(chara => [chara.fav1, chara.fav2].includes(fav));
 
-const range_sex = (sex) => range_custom(v => v.sex === sex);
+const range_sex = (sex) => range_custom(chara => chara.sex === sex);
 
 
 const when_element_buff = (chara, buff) => (chara.elementBuff > 0 || buff.element > 0);

--- a/src/support_filter.test.js
+++ b/src/support_filter.test.js
@@ -1,0 +1,80 @@
+const {range, when} = require("./support_filter.js");
+
+
+describe("support.range", () => {
+    
+    const totals = {
+        "Djeeta": {
+            element: "light",
+            fav1: "sword",
+            fav2: "axe",
+            race: "unknown",
+            sex: "female",
+            isConsideredInAverage: true,
+        },
+        "CharaA": {
+            element: "light",
+            fav1: "sword",
+            fav2: "",
+            race: "unknown",
+            sex: "female",
+            isConsideredInAverage: true,
+        },
+        "CharaB": {
+            element: "fire",
+            fav1: "sword",
+            fav2: "fist",
+            race: "doraf",
+            sex: "male",
+            isConsideredInAverage: true,
+        },
+        "CharaC": {
+            element: "wind",
+            fav1: "katana",
+            fav2: "fist",
+            race: "havin",
+            sex: "other",
+            isConsideredInAverage: true,
+        },
+    }
+    
+    it("range_own", () => {
+        const result = range.own(totals, "Djeeta");
+        const [name, chara] = result[0];
+        expect(chara).toBe(totals["Djeeta"]);
+    });
+    
+    it("range_all", () => {
+        expect(range.all(totals, "Djeeta").length).toBe(4);
+    });
+    
+    it("range_others", () => {
+        expect(range.others(totals, "Djeeta").length).toBe(3);
+    });
+    
+    it("range_light", () => {
+        expect(range.element("light")(totals, "Djeeta").length).toBe(2);
+    });
+    
+    it("range_fist", () => {
+        expect(range.fav("fist")(totals, "Djeeta").length).toBe(2);
+    });
+
+    it("range_race", () => {
+        expect(range.race("unknown")(totals, "Djeeta").length).toBe(2);
+    });
+    
+    it("range_custom", () => {
+        const range_female = range.custom(v => v.sex === "female");
+        expect(range_female(totals, "Djeeta").length).toBe(2);
+    });
+});
+
+
+describe("support.when", () => {
+    it("when.element_buff", () => {
+        expect(when.element_buff({elementBuff:0}, {element:0})).toBeFalsy();
+        expect(when.element_buff({elementBuff:1}, {element:0})).toBeTruthy();
+        expect(when.element_buff({elementBuff:0}, {element:1})).toBeTruthy();
+    });
+});

--- a/src/support_filter.test.js
+++ b/src/support_filter.test.js
@@ -61,7 +61,7 @@ describe("support.range", () => {
     })
     
     it("range_light", () => {
-        expect(range.element("light")(totals, "Djeeta").length).toBe(2);
+        expect(range.element.light(totals, "Djeeta").length).toBe(2);
     });
     
     it("range_fist", () => {

--- a/src/support_filter.test.js
+++ b/src/support_filter.test.js
@@ -51,6 +51,14 @@ describe("support.range", () => {
     it("range_others", () => {
         expect(range.others(totals, "Djeeta").length).toBe(3);
     });
+
+    it("range_none", () => {
+        expect(range.none(totals, "Djeeta").length).toBe(0);
+    })
+
+    it("range_Djeeta", () => {
+        expect(range.Djeeta(totals, "CharaA").length).toBe(1);
+    })
     
     it("range_light", () => {
         expect(range.element("light")(totals, "Djeeta").length).toBe(2);

--- a/src/translate.js
+++ b/src/translate.js
@@ -2235,9 +2235,9 @@ var multiLangData = {
         "ja": "味方全体の強化効果「属性攻撃UP」の効果30%UP。",
         "zh": "All Allies gain an additional 30% boost to Element ATK when affected by Element ATK Buff.",
     },
-    "属性攻撃UPが付与されている時、自分の攻撃UP。(ヘルエス(風属性ver)": {
+    "属性攻撃UPが付与されている時、自分の攻撃UP。(ヘルエス(風属性ver))": {
         "en": "30% boost to ATK when affected by Element ATK Buff (Heles (Wind))",
-        "ja": "属性攻撃UPが付与されている時、自分の攻撃UP。(ヘルエス(風属性ver)",
+        "ja": "属性攻撃UPが付与されている時、自分の攻撃UP。(ヘルエス(風属性ver))",
         "zh": "30% boost to ATK when affected by Element ATK Buff (Heles (Wind))",
     },
     "自分以外の味方の攻5%UPとクリティカル確率UP(発動率20%, 倍率20%)。(ヤイア)": {

--- a/src/translate.js
+++ b/src/translate.js
@@ -2040,10 +2040,10 @@ var multiLangData = {
         "ja": "バトルメンバーの種族数に応じて攻撃力UP(リリィ)",
         "zh": "バトルメンバーの種族数に応じて攻撃力UP(リリィ)",
     },
-    "属性バフ付与時に属性攻撃30%UP(パーシヴァル)": {
-        "en": "Gain an additional 30% boost to Elemental buffs when affected by Elemental Buff (Percival)",
-        "ja": "属性バフ付与時に属性攻撃30%UP(パーシヴァル)",
-        "zh": "属性バフ付与時に属性攻撃30%UP(パーシヴァル)",
+    "属性バフ付与時に属性攻撃30%UP(パーシヴァル,アグロヴァル)": {
+        "en": "Gain an additional 30% boost to Elemental buffs when affected by Elemental Buff (Percival,Agloval)",
+        "ja": "属性バフ付与時に属性攻撃30%UP(パーシヴァル,アグロヴァル)",
+        "zh": "属性バフ付与時に属性攻撃30%UP(パーシヴァル,アグロヴァル)",
     },
     "属性バフ付与時にステータスUP(スカーサハ)": {
         "en": "Boost to ATK and multiattack rate when buffed by Elemental Buff (Scathacha)",
@@ -2235,15 +2235,10 @@ var multiLangData = {
         "ja": "味方全体の強化効果「属性攻撃UP」の効果30%UP。",
         "zh": "All Allies gain an additional 30% boost to Element ATK when affected by Element ATK Buff.",
     },
-    "属性バフ付与時に属性攻撃15%UPと奥義性能UP(ダメージと上限20%)。(アグロヴァル)": {
-        "en": "Gain an additional 30% boost to Element ATK and 20% Boost to C.A. Damage and Cap, when affected by Element ATK Buff. (Aglovale)",
-        "ja": "属性バフ付与時に属性攻撃15%UPと奥義性能UP(ダメージと上限20%)。(アグロヴァル)",
-        "zh": "Gain an additional 30% boost to Element ATK and 20% Boost to C.A. Damage and Cap, when affected by Element ATK Buff. (Aglovale)",
-    },
-    "属性攻撃UPが付与されている時、自分の攻撃UPと奥義性能UP(ダメージと上限20%)。(ヘルエス(風属性ver))": {
-        "en": "30% boost to ATK and 20% Boost to C.A. Damage and Cap, when affected by Element ATK Buff (Heles (Wind))",
-        "ja": "属性攻撃UPが付与されている時、自分の攻撃UPと奥義性能UP(ダメージと上限20%)。(ヘルエス(風属性ver))",
-        "zh": "30% boost to ATK and 20% Boost to C.A. Damage and Cap, when affected by Element ATK Buff (Heles (Wind))",
+    "属性攻撃UPが付与されている時、自分の攻撃UP。(ヘルエス(風属性ver)": {
+        "en": "30% boost to ATK when affected by Element ATK Buff (Heles (Wind))",
+        "ja": "属性攻撃UPが付与されている時、自分の攻撃UP。(ヘルエス(風属性ver)",
+        "zh": "30% boost to ATK when affected by Element ATK Buff (Heles (Wind))",
     },
     "自分以外の味方の攻5%UPとクリティカル確率UP(発動率20%, 倍率20%)。(ヤイア)": {
         "en": "All Other Allies gain gain 5% ATK UP and Boost to critical hit rate (20% chance, 20% damage). (Yaia)",


### PR DESCRIPTION
PR for MotocalDevelopers/motocal/pull/259

- Implement "support.range" filtering idea
  - range: all, own, others, element etc
    no more clone code for isConsideredInAverage:off case
  - and also "when" for element buff
- Remove ougi effects (Heles(Wind), Agloval), they are not support
  (I will explain they should be separate, for reuse of support)
- Olivia's support use "when.element_buff"
- "element_buff_boost", "critical_cap_up" use "support.range"
- continue for "no_normal_attack"

----
support.range filtering

- the filtering function will switch filter-function by totals[key].isConsideredInAverage
  no need to write same clone code for isConsideredInAverage, anymore.
- the implementation details is a bit like pazzle of function
  I assume unit tests and sample codes will support to understand.
  or write document for them. it's simple for use.
- when.element_buff in logic code directly ... I did not add to "support.when"
  Because many similar supports for each elements.
  they does not need to have "when" field since it's same "type".
  Merit here is reuse of the element buff check code.

----
"no_normal_attack" should not fallthrough to konshin
this below code will mean, all "no_normal_attack" has konshin skill.
but it's for Sakura specific. it's ~~not~~ now unused, I just put "continue" there.

```js
case "no_normal_attack":
case "normalSupportKonshin_hpDebuff":
```

----
Remove ougi effects (Heles(Wind), Agloval)

It's temporary change, support should not contains ougi effects.
we can discuss how to implement them later. (add "ougi" field like "support" ?)

After remove the ougi effects, Agloval's support can be same to Percival.