### PR TITLE
Add skill display for additionalDamageXA

### DIFF
--- a/src/global_const.js
+++ b/src/global_const.js
@@ -2249,13 +2249,13 @@ var supportAbilities = {
         "name": "1回攻撃と2回攻撃時に火属性追加ダメージ発生(1回:80%、 2回:30%)。(スツルム)",
         "type": "additionalDamageXA",
         "range": "own",
-        "additionalDamageXA": [0.8, 0.3, 0.0]
+        "value": [0.8, 0.3, 0.0]
     },
     "Revion_kishi_sanshimai": {
         "name": "3回攻撃時に追加ダメージ発生(15%)。(レヴィオン姉妹 マイム＆ミイム＆メイム)",
         "type": "additionalDamageXA",
         "range": "own",
-        "additionalDamageXA": [0.0, 0.0, 0.15]
+        "value": [0.0, 0.0, 0.15]
     },
     "element_buff_boost_damageUP_own_10": {
         "name": "属性攻撃力UPが付与されている時、与ダメージ上昇10%UP。(オリヴィエ)",

--- a/src/global_logic.js
+++ b/src/global_logic.js
@@ -908,6 +908,7 @@ module.exports.calcBasedOneSummon = function (summonind, prof, buff, totals) {
         coeffs["hpRatio"] = hpCoeff;
         coeffs["ougiGageBuff"] = ougiGageBuff - 1.0;
         coeffs["additionalDamage"] = additionalDamage;
+        coeffs["additionalDamageXA"] = totals[key]["additionalDamageXA"];
         coeffs["ougiDamageUP"] = ougiDamageUP;
         coeffs["chainDamageUP"] = chainDamageUP;
         coeffs["damageUP"] = damageUP;

--- a/src/result.js
+++ b/src/result.js
@@ -1309,6 +1309,31 @@ var Result = CreateClass({
                             );
                         }
 
+                        var additionalInfo = [];
+                        if (skilldata["additionalDamageXA"]) {
+                            let {additionalDamageXA} = skilldata;
+                            console.log(additionalDamageXA)
+                            additionalInfo.push(
+                                <table key={key + "-additionalInfoTable"} className="table table-bordered"
+                                       style={{"marginBottom": "0px", "fontSize": "10pt"}}>
+                                    <thead>
+                                    <tr>
+                                        <th className="bg-success">{intl.translate("追加ダメージXA", locale)}</th>
+                                        <th className="bg-success">SA</th>
+                                        <th className="bg-success">DA</th>
+                                        <th className="bg-success">TA</th>
+                                    </tr>
+                                    </thead>
+                                    <tbody>
+                                    <tr>
+                                        <td>{intl.translate("効果量", locale)}</td>
+                                        {additionalDamageXA.map(value => <td>{Math.round(value*100)}%</td>)}
+                                    </tr>
+                                    </tbody>
+                                </table>
+                            );
+                        }
+
                         var supplementalDamageInfo = [];
                         const supplementalInfo = supplemental.collectSkillInfo(skilldata.supplementalDamageArray, {remainHP: m.data[key].remainHP});
                         if (supplementalInfo.total > 0) {
@@ -1375,6 +1400,8 @@ var Result = CreateClass({
                         charaDetail[key].push(<div key={key + "-multipleAttackInfo"}>{multipleAttackSkillInfo}</div>);
                         charaDetail[key].push(<div key={key + "-criticalInfo"}
                                                    style={{"margin": "5px 0px"}}>{criticalInfo}</div>);
+                        charaDetail[key].push(<div key={key + "-additionalInfo"}
+                                                   style={{"margin": "5px 0px"}}>{additionalInfo}</div>);
                         charaDetail[key].push(<div key={key + "-supplementalDamageInfo"}
                                                    style={{"margin": "5px 0px"}}>{supplementalDamageInfo}</div>);
                         charaDetail[key].push(<div key={key + "-otherSkillInfo"}>{otherSkillInfo}</div>);

--- a/src/result.js
+++ b/src/result.js
@@ -1312,7 +1312,6 @@ var Result = CreateClass({
                         var additionalInfo = [];
                         if (skilldata["additionalDamageXA"]) {
                             let {additionalDamageXA} = skilldata;
-                            console.log(additionalDamageXA)
                             additionalInfo.push(
                                 <table key={key + "-additionalInfoTable"} className="table table-bordered"
                                        style={{"marginBottom": "0px", "fontSize": "10pt"}}>

--- a/src/translate.js
+++ b/src/translate.js
@@ -316,6 +316,16 @@ var multiLangData = {
         "ja": "TA率が上がります。各キャラの基礎TA率に加算されます。四天刃(30%)、エタラブ(35%)など。",
         "zh": "TA率上升。加在每个角色的基础DA率上。",
     },
+    "効果量": {
+        "en": "Amount",
+        "ja": "効果量",
+        "zh": "Amount",
+    },
+    "追加ダメージXA": { // additionalDamageXA
+        "en": "Bonus DMG XA",
+        "ja": "連撃時追加ダメージ",
+        "zh": "追加伤害 XA",
+    },
     "追加ダメージ": {
         "en": "Bonus DMG", //a.k.a: additionalDamage
         "ja": "追加ダメージ",


### PR DESCRIPTION
PR for MotocalDevelopers/motocal/pull/259

- Fix support field name for value
  - that's why I need this display, I could not check the effect.
  - I would like to use "value" field as variant for support parameters
    - "support" can be object which has same interfaces.
- [ ] Math.round for display the amount, currently no halfway value.
- [ ] translation label, there was already used "Bonus DMG" I don't have idea.
   - for Japanese translation, I put 連撃時追加ダメージ
     that means "at the multiple attacks time" (although there is SA)

![XA](https://user-images.githubusercontent.com/45387555/60401176-876f0b00-9bb8-11e9-93d7-39b39065d3ec.PNG)
